### PR TITLE
Example updated so it works with current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is a simple Telegram bot that replies to every user message with the same m
 * Have **Go** installed  
 https://golang.org
 * Have **telegram-bot-api** installed  
-```go get github.com/Syfaro/telegram-bot-api```
+```go get github.com/go-telegram-bot-api/telegram-bot-api```
 
 ## How to use this
 1. Download this repo
 2. Change *HERE_GOES_YOUR_APP_ID* for your AppEngine app's ID in *app.yaml*
 3. Change *HERE_GOES_YOUR_TELEGRAM_BOT_TOKEN* for your Telegram Bot Token
-4. Deploy your app: ```goapp deploy -oauth app.yaml```
+4. Deploy your app: ```goapp deploy app.yaml```
 5. Go to http://APP_ID.appspot.com/YOUR_TOKEN/start to create the Webhook (you can go to */YOUR_TOKEN/stop* to remove the Webhook)
 
 ## How does this work?

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -4,7 +4,7 @@ import (
 	"appengine"
 	"appengine/urlfetch"
 	"encoding/json"
-	"github.com/Syfaro/telegram-bot-api"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"io/ioutil"
 	"net/http"
 )
@@ -69,5 +69,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	msg := tgbotapi.NewMessage(update.Message.Chat.ID, update.Message.Text)
 	msg.ReplyToMessageID = update.Message.MessageID
 
-	bot.SendMessage(msg)
+	bot.Send(msg)
 }


### PR DESCRIPTION
Just added some changes so that the example builds with the current api. Updated the URL for the api as well as removed the -oauth flag from deployment command since that is now on by default.